### PR TITLE
Fix Claude CLI prompt input method

### DIFF
--- a/claude-executor.js
+++ b/claude-executor.js
@@ -21,7 +21,6 @@ function executeClaudeCommand(prompt, claudeSessionId, workspacePath, options = 
     args.push('--disallowedTools', options.disallowedTools.join(','))
   }
 
-  args.push(prompt)
 
   return spawn('claude', args, {
     cwd: workspacePath,
@@ -62,6 +61,7 @@ async function executeClaudeAndStream(prompt, claudeSessionId, options, reply) {
 
   claudeProcess.on('spawn', () => {
     console.log('Claude process spawned successfully')
+    claudeProcess.stdin.write(prompt)
     claudeProcess.stdin.end()
   })
 


### PR DESCRIPTION
## Summary
  - Fix Claude CLI execution error by passing prompt via stdin instead of
  command line argument
  - Resolves "Input must be provided either through stdin or as a prompt
  argument when using --print" error

  ## Problem
  The Claude CLI was failing with error:
  Claude stderr: Error: Input must be provided either through stdin or as a
   prompt argument when using --print
  Claude process exited with code 1

  This occurred because the prompt was being passed as a command line
  argument, but when using the `--print` (`-p`) flag, Claude CLI expects
  input via stdin.

  ## Changes
  **File: `claude-executor.js`**
  - **Line 24**: Remove `args.push(prompt)` from command argument
  construction
  - **Line 65**: Add `claudeProcess.stdin.write(prompt)` to pass prompt via
   stdin after process spawn
  - Maintain existing functionality while fixing CLI compatibility

  ## Root Cause
  The issue was in `executeClaudeCommand()` function where we were
  constructing CLI arguments with:
  ```javascript
  args.push(prompt)  // ❌ Wrong approach for -p flag

  But Claude CLI with --print flag expects stdin input, not command
  arguments.

  Solution

  Now we properly write the prompt to stdin:
  claudeProcess.on('spawn', () => {
    console.log('Claude process spawned successfully')
    claudeProcess.stdin.write(prompt)  // ✅ Correct approach
    claudeProcess.stdin.end()
  })
  ```

  Test plan

  - Test API endpoint with basic prompt:
  curl -X POST http://localhost:3000/api/claude \
    -H "Content-Type: application/json" \
    -d '{"prompt": "Hello world", "allowedTools": ["Read", "Edit", "Write",
   "Bash"]}' \
    -N
  - Test with Japanese prompt:
  curl -X POST http://localhost:3000/api/claude \
    -H "Content-Type: application/json" \
    -d '{"prompt": "ファイルを作成して", "allowedTools": ["Read", "Edit", 
  "Write", "Bash"]}' \
    -N
  - Verify Claude process no longer exits with code 1
  - Confirm prompt is properly received by Claude CLI
  - Test various prompt lengths and special characters
  - Verify all existing functionality (session management, tools, timeouts)
   still works

  Impact

  - Fixes critical bug: Claude CLI now executes successfully instead of
  failing immediately
  - No functional changes: All existing features continue to work as
  expected
  - Better compatibility: Aligns with Claude CLI's expected input method
  for --print flag
  - Improved reliability: Eliminates process exit errors that were
  preventing any Claude operations

  Breaking Changes

  None - this is a pure bug fix that makes the existing functionality work
  as intended.

  Additional Notes

  This fix ensures the Claude Code Server can properly communicate with the
   Claude CLI, which is essential for all server functionality. Without
  this fix, all API requests to /api/claude would fail with the stdin input
   error.