### PR TITLE
feat: add system prompt support for both API endpoints

### DIFF
--- a/claude-executor.js
+++ b/claude-executor.js
@@ -14,6 +14,10 @@ function executeClaudeCommand(prompt, claudeSessionId, workspacePath, options = 
     args.push('--dangerously-skip-permissions')
   }
 
+  if (options.systemPrompt) {
+    args.push('--system-prompt', options.systemPrompt)
+  }
+
   // Collect all allowed tools (regular + MCP)
   let allAllowedTools = []
   if (options.allowedTools && options.allowedTools.length > 0) {


### PR DESCRIPTION
## Summary
  - Add systemPrompt parameter support to /api/claude endpoint  
  - Extract system messages from /v1/chat/completions endpoint (OpenAI compatible)
  - Pass system prompts to Claude CLI using --system-prompt flag
  - Add proper logging for system prompt usage

  ## Changes Made
  - **server.js**: Added systemPrompt parameter to /api/claude schema and request handling
  - **server.js**: Extract system message from first message in /v1/chat/completions when role is "system"
  - **claude-executor.js**: Add --system-prompt flag support to Claude command execution
  - **Both endpoints**: Added system prompt logging and proper parameter passing

  ## Test Plan
  - [ ] Test /api/claude endpoint with systemPrompt parameter
  - [ ] Test /v1/chat/completions endpoint with system message as first message
  - [ ] Verify system prompts are properly logged in console output
  - [ ] Confirm Claude CLI receives --system-prompt flag correctly