### PR TITLE
feat: add configurable workspace path via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Environment variables for Claude Code Server
+
+# Base directory for workspace creation
+# Default: project root directory
+# Example: WORKSPACE_BASE_PATH=/tmp/claude-workspaces
+WORKSPACE_BASE_PATH=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,12 @@ The server follows a modular architecture with clear separation of concerns:
 
 ### Configuration Files
 - `mcp-config.json` - MCP server configurations (create from `mcp-config.json.example`)
+- `.env` - Environment variables for server configuration (optional)
 - Workspace directories are auto-created and gitignored
+
+### Environment Variables
+- `WORKSPACE_BASE_PATH` - Base directory for workspace creation (default: project root directory)
+  - Example: `WORKSPACE_BASE_PATH=/tmp/claude-workspaces`
 
 ### Dependencies
 - Requires Claude Code CLI v1.0.18+ to be installed and configured

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ claude-code-server/
 ├── .eslintrc.js           # ESLint configuration
 ├── .prettierrc            # Prettier configuration
 ├── .husky/                # Git hooks for code quality
+├── .env                   # Environment variables (gitignored)
+├── .env.example           # Environment variables template
 ├── mcp-config.json        # MCP server configuration (gitignored)
 ├── mcp-config.json.example # MCP configuration template
 ├── shared_workspace/      # Default workspace (gitignored)
@@ -153,6 +155,21 @@ cp mcp-config.json.example mcp-config.json
 1. **Shared Workspace** (default): `shared_workspace/`
 2. **Custom Workspace**: `workspace/{workspace-name}/`
 
+### Configurable Workspace Location
+
+You can customize the base directory for all workspaces using environment variables:
+
+```bash
+# Create .env file
+cp .env.example .env
+
+# Edit .env file
+WORKSPACE_BASE_PATH=/tmp/claude-workspaces
+```
+
+**Environment Variables:**
+- `WORKSPACE_BASE_PATH` - Base directory for workspace creation (default: project root directory)
+
 ### Usage Examples
 
 **Shared workspace:**
@@ -205,6 +222,10 @@ curl -X POST http://localhost:3000/api/claude \
 ```bash
 # Install dependencies
 npm install
+
+# Setup environment variables (optional)
+cp .env.example .env
+# Edit .env with your configuration (e.g., WORKSPACE_BASE_PATH)
 
 # Setup MCP configuration (optional)
 cp mcp-config.json.example mcp-config.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@fastify/cors": "^9.x",
+        "dotenv": "^16.x",
         "fastify": "^4.x"
       },
       "devDependencies": {
@@ -1058,6 +1059,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "dist/server.js",
   "dependencies": {
     "fastify": "^4.x",
-    "@fastify/cors": "^9.x"
+    "@fastify/cors": "^9.x",
+    "dotenv": "^16.x"
   },
   "devDependencies": {
     "typescript": "^5.x",

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -4,6 +4,7 @@
 
 import { promises as fs } from 'fs';
 import * as path from 'path';
+import 'dotenv/config';
 
 /**
  * Create workspace directory for Claude session
@@ -11,12 +12,13 @@ import * as path from 'path';
  * @returns Path to created workspace directory
  */
 export async function createWorkspace(workspaceName: string | null = null): Promise<string> {
+  const baseWorkspacePath = process.env.WORKSPACE_BASE_PATH || path.join(__dirname, '..');
   let workspacePath: string;
 
   if (workspaceName) {
-    workspacePath = path.join(__dirname, '..', 'workspace', workspaceName);
+    workspacePath = path.join(baseWorkspacePath, 'workspace', workspaceName);
   } else {
-    workspacePath = path.join(__dirname, '..', 'shared_workspace');
+    workspacePath = path.join(baseWorkspacePath, 'shared_workspace');
   }
 
   await fs.mkdir(workspacePath, { recursive: true });


### PR DESCRIPTION
## Summary
- Add support for configuring workspace directory location via `WORKSPACE_BASE_PATH` environment variable
- Maintain backward compatibility with existing default behavior
- Add comprehensive documentation and example configuration

## Changes
- **session-manager.ts**: Use `WORKSPACE_BASE_PATH` environment variable for workspace creation
- **package.json**: Add `dotenv` dependency for environment variable handling
- **.env.example**: Provide example configuration file
- **CLAUDE.md**: Update documentation with environment variable usage

## Test plan
- [ ] Test default behavior (no environment variable set)
- [ ] Test custom workspace path via environment variable
- [ ] Verify both shared workspace and named workspaces work correctly
- [ ] Confirm backward compatibility with existing installations

🤖 Generated with [Claude Code](https://claude.ai/code)