### PR TITLE
feat: add configurable environment variables for server settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,33 @@
 # Environment variables for Claude Code Server
 
+# Server Configuration
+# Port for the server to listen on
+# Default: 3000
+PORT=3000
+
+# Host address for the server to bind to
+# Default: 0.0.0.0
+HOST=0.0.0.0
+
+# Claude Process Timeout Settings
+# Total timeout for Claude processes in milliseconds
+# Default: 3600000 (1 hour)
+CLAUDE_TOTAL_TIMEOUT_MS=3600000
+
+# Inactivity timeout for Claude processes in milliseconds
+# Default: 300000 (5 minutes)
+CLAUDE_INACTIVITY_TIMEOUT_MS=300000
+
+# Timeout before force-killing processes in milliseconds
+# Default: 5000 (5 seconds)
+PROCESS_KILL_TIMEOUT_MS=5000
+
+# MCP Configuration
+# Path to MCP configuration file
+# Default: ../mcp-config.json (relative to dist directory)
+MCP_CONFIG_PATH=
+
+# Workspace Configuration
 # Base directory for workspace creation
 # Default: project root directory
 # Example: WORKSPACE_BASE_PATH=/tmp/claude-workspaces

--- a/README.md
+++ b/README.md
@@ -168,7 +168,16 @@ WORKSPACE_BASE_PATH=/tmp/claude-workspaces
 ```
 
 **Environment Variables:**
-- `WORKSPACE_BASE_PATH` - Base directory for workspace creation (default: project root directory)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `3000` | Port for the server to listen on |
+| `HOST` | `0.0.0.0` | Host address for the server to bind to |
+| `CLAUDE_TOTAL_TIMEOUT_MS` | `3600000` | Total timeout for Claude processes (1 hour) |
+| `CLAUDE_INACTIVITY_TIMEOUT_MS` | `300000` | Inactivity timeout for Claude processes (5 minutes) |
+| `PROCESS_KILL_TIMEOUT_MS` | `5000` | Timeout before force-killing processes (5 seconds) |
+| `MCP_CONFIG_PATH` | `../mcp-config.json` | Path to MCP configuration file |
+| `WORKSPACE_BASE_PATH` | project root | Base directory for workspace creation |
 
 ### Usage Examples
 
@@ -240,6 +249,24 @@ npm start
 ```
 
 The server runs on `http://localhost:3000`
+
+### Custom Configuration
+
+You can customize server behavior using environment variables:
+
+```bash
+# Start server on custom port and host
+PORT=8080 HOST=127.0.0.1 npm start
+
+# Set custom timeouts (in milliseconds)
+CLAUDE_TOTAL_TIMEOUT_MS=7200000 CLAUDE_INACTIVITY_TIMEOUT_MS=600000 npm start
+
+# Use custom workspace location
+WORKSPACE_BASE_PATH=/tmp/my-workspaces npm start
+
+# Combine multiple settings
+PORT=8080 WORKSPACE_BASE_PATH=/tmp/workspaces npm start
+```
 
 ### Development
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -491,7 +491,10 @@ async function startServer(): Promise<void> {
   );
 
   try {
-    await server.listen({ port: 3000, host: '0.0.0.0' });
+    await server.listen({
+      port: parseInt(process.env.PORT || '3000', 10),
+      host: process.env.HOST || '0.0.0.0',
+    });
   } catch (err) {
     server.log.error(err);
     process.exit(1);


### PR DESCRIPTION
## Summary
- Replace hardcoded configuration values with environment variables
- Add PORT and HOST configuration for server binding
- Add configurable timeouts for Claude processes (total, inactivity, kill timeout)
- Add MCP_CONFIG_PATH for custom MCP configuration file location
- All variables include sensible defaults for backward compatibility

## Changes Made
- **server.ts**: PORT and HOST environment variables for server configuration
- **claude-executor.ts**: Timeout environment variables (CLAUDE_TOTAL_TIMEOUT_MS, CLAUDE_INACTIVITY_TIMEOUT_MS, PROCESS_KILL_TIMEOUT_MS) and MCP_CONFIG_PATH
- **.env.example**: Added all new environment variables with documentation
- **README.md**: Updated environment variables section with detailed table and usage examples
- **CLAUDE.md**: Updated for Claude Code reference with environment variable documentation

## Environment Variables Added
 < /dev/null |  Variable | Default | Description |
|----------|---------|-------------|
| `PORT` | `3000` | Port for the server to listen on |
| `HOST` | `0.0.0.0` | Host address for the server to bind to |
| `CLAUDE_TOTAL_TIMEOUT_MS` | `3600000` | Total timeout for Claude processes (1 hour) |
| `CLAUDE_INACTIVITY_TIMEOUT_MS` | `300000` | Inactivity timeout for Claude processes (5 minutes) |
| `PROCESS_KILL_TIMEOUT_MS` | `5000` | Timeout before force-killing processes (5 seconds) |
| `MCP_CONFIG_PATH` | `../mcp-config.json` | Path to MCP configuration file |

## Test Plan
- [x] TypeScript compilation succeeds
- [x] ESLint passes  
- [x] Code builds successfully
- [x] Server starts with default values
- [x] Server starts with custom PORT and HOST environment variables
- [x] All environment variables have proper fallbacks
- [x] Documentation is comprehensive and accurate

Resolves #18

🤖 Generated with [Claude Code](https://claude.ai/code)