### PR TITLE
feat: add health check endpoint for server monitoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Testing the Server
 Test the API endpoints using curl (default port 3000):
 ```bash
+# Health check endpoint
+curl http://localhost:3000/health
+
 # Basic request to /api/claude endpoint
 curl -X POST http://localhost:3000/api/claude \
   -H "Content-Type: application/json" \
@@ -35,6 +38,7 @@ curl -X POST http://localhost:3000/v1/chat/completions \
   -d '{"model": "claude-code", "messages": [{"role": "user", "content": "Hello"}], "stream": true}'
 
 # Test with custom port (if PORT environment variable is set)
+curl http://localhost:8080/health
 curl -X POST http://localhost:8080/api/claude \
   -H "Content-Type: application/json" \
   -d '{"prompt": "List files"}'
@@ -45,7 +49,8 @@ curl -X POST http://localhost:8080/api/claude \
 ### Core Components
 The server follows a modular architecture with clear separation of concerns:
 
-1. **server.js** - Main Fastify server with two API endpoints:
+1. **server.js** - Main Fastify server with three API endpoints:
+   - `/health` - Health check endpoint for monitoring server status
    - `/api/claude` - Direct Claude Code API with all parameters in request body
    - `/v1/chat/completions` - OpenAI-compatible streaming endpoint
 
@@ -62,6 +67,12 @@ The server follows a modular architecture with clear separation of concerns:
    - Loads `mcp-config.json` configuration at startup
    - Validates MCP tool names against configured servers
    - Enables external tool integration (e.g., GitHub, DeepWiki)
+
+5. **health-checker.js** - Health monitoring system:
+   - Checks Claude CLI availability and version
+   - Verifies workspace directory accessibility and permissions
+   - Monitors MCP configuration status
+   - Provides comprehensive system health reporting
 
 ### Key Architecture Patterns
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Claude Code Server is a Fastify-based server that wraps the Claude Code CLI (v1.
 ## Features
 
 - **Streaming API**: Real-time Claude Code responses via Server-Sent Events
+- **Health Monitoring**: Built-in health check endpoint for system monitoring
 - **Workspace Management**: Isolated workspaces with custom naming or shared workspace
 - **System Prompt Support**: Custom system prompts for both API endpoints
 - **MCP Support**: Integration with Model Context Protocol for external tools
@@ -36,10 +37,11 @@ claude-code-server/
 │   └── workflows/
 │       └── ci.yml          # GitHub Actions CI/CD workflow
 ├── src/
-│   ├── server.ts           # Fastify server with dual API endpoints
+│   ├── server.ts           # Fastify server with API endpoints
 │   ├── claude-executor.ts  # Claude Code execution with MCP support
 │   ├── session-manager.ts  # Workspace management
 │   ├── mcp-manager.ts      # MCP configuration handling
+│   ├── health-checker.ts   # Health monitoring system
 │   └── types.ts            # TypeScript type definitions
 ├── dist/                   # Compiled TypeScript output
 ├── package.json
@@ -73,6 +75,60 @@ claude-code-server/
 | `mcp-allowed-tools` | string[] | Allowed MCP tools | `["mcp__github__get_repo"]` |
 
 ## API Endpoints
+
+### GET /health
+
+Health check endpoint for monitoring server status.
+
+**Response:**
+```json
+{
+  "status": "healthy",
+  "timestamp": "2025-06-14T16:25:58.963Z",
+  "uptime": 129.465,
+  "version": "1.0.0",
+  "checks": {
+    "claudeCli": {
+      "status": "healthy",
+      "message": "Claude CLI is available and responsive",
+      "details": {
+        "version": "1.0.24 (Claude Code)",
+        "exitCode": 0
+      },
+      "timestamp": "2025-06-14T16:25:58.963Z"
+    },
+    "workspace": {
+      "status": "healthy",
+      "message": "Workspace directory is accessible and writable",
+      "details": {
+        "path": "/path/to/workspace",
+        "readable": true,
+        "writable": true
+      },
+      "timestamp": "2025-06-14T16:25:58.965Z"
+    },
+    "mcpConfig": {
+      "status": "healthy",
+      "message": "MCP is disabled (no configuration file found)",
+      "details": {
+        "enabled": false,
+        "configPath": "/path/to/mcp-config.json"
+      },
+      "timestamp": "2025-06-14T16:25:58.965Z"
+    }
+  }
+}
+```
+
+**Status Codes:**
+- `200` - Healthy or degraded (still operational)
+- `503` - Unhealthy (service unavailable)
+- `500` - Internal server error
+
+**Health Status Values:**
+- `healthy` - All checks passed
+- `degraded` - Some issues detected but still operational
+- `unhealthy` - Critical issues detected, service may not work properly
 
 ### POST /api/claude
 

--- a/src/health-checker.ts
+++ b/src/health-checker.ts
@@ -1,0 +1,302 @@
+/**
+ * Health check utilities for server monitoring
+ */
+
+import { spawn } from 'child_process';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { getMcpConfig, isMcpEnabled } from './mcp-manager';
+
+/**
+ * Health check result interface
+ */
+export interface HealthCheckResult {
+  status: 'healthy' | 'unhealthy' | 'degraded';
+  message: string;
+  details?: Record<string, unknown>;
+  timestamp: string;
+}
+
+/**
+ * Overall health status interface
+ */
+export interface HealthStatus {
+  status: 'healthy' | 'unhealthy' | 'degraded';
+  timestamp: string;
+  uptime: number;
+  version: string;
+  checks: {
+    claudeCli: HealthCheckResult;
+    workspace: HealthCheckResult;
+    mcpConfig: HealthCheckResult;
+  };
+}
+
+/**
+ * Check if Claude CLI is available and working
+ */
+export async function checkClaudeCli(): Promise<HealthCheckResult> {
+  const timestamp = new Date().toISOString();
+
+  try {
+    return new Promise(resolve => {
+      const claudeProcess = spawn('claude', ['--version'], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 5000,
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      claudeProcess.stdout?.on('data', data => {
+        stdout += data.toString();
+      });
+
+      claudeProcess.stderr?.on('data', data => {
+        stderr += data.toString();
+      });
+
+      claudeProcess.on('close', code => {
+        if (code === 0) {
+          resolve({
+            status: 'healthy',
+            message: 'Claude CLI is available and responsive',
+            details: {
+              version: stdout.trim(),
+              exitCode: code,
+            },
+            timestamp,
+          });
+        } else {
+          resolve({
+            status: 'unhealthy',
+            message: 'Claude CLI returned non-zero exit code',
+            details: {
+              exitCode: code,
+              stdout: stdout.trim(),
+              stderr: stderr.trim(),
+            },
+            timestamp,
+          });
+        }
+      });
+
+      claudeProcess.on('error', error => {
+        resolve({
+          status: 'unhealthy',
+          message: 'Claude CLI is not available or not working',
+          details: {
+            error: error.message,
+            name: error.name,
+          },
+          timestamp,
+        });
+      });
+
+      // Handle timeout
+      setTimeout(() => {
+        if (!claudeProcess.killed) {
+          claudeProcess.kill('SIGTERM');
+          resolve({
+            status: 'unhealthy',
+            message: 'Claude CLI check timed out',
+            details: {
+              timeout: '5000ms',
+            },
+            timestamp,
+          });
+        }
+      }, 5000);
+    });
+  } catch (error) {
+    return {
+      status: 'unhealthy',
+      message: 'Failed to check Claude CLI',
+      details: {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      timestamp,
+    };
+  }
+}
+
+/**
+ * Check workspace directory accessibility
+ */
+export async function checkWorkspace(): Promise<HealthCheckResult> {
+  const timestamp = new Date().toISOString();
+  const baseWorkspacePath = process.env.WORKSPACE_BASE_PATH || path.join(__dirname, '..');
+
+  try {
+    // Check if base workspace path exists and is accessible
+    const stats = await fs.stat(baseWorkspacePath);
+
+    if (!stats.isDirectory()) {
+      return {
+        status: 'unhealthy',
+        message: 'Workspace base path is not a directory',
+        details: {
+          path: baseWorkspacePath,
+          type: 'file',
+        },
+        timestamp,
+      };
+    }
+
+    // Try to create a test directory to verify write permissions
+    const testDir = path.join(baseWorkspacePath, '.health-check-test');
+    try {
+      await fs.mkdir(testDir, { recursive: true });
+      await fs.rmdir(testDir);
+
+      return {
+        status: 'healthy',
+        message: 'Workspace directory is accessible and writable',
+        details: {
+          path: baseWorkspacePath,
+          readable: true,
+          writable: true,
+        },
+        timestamp,
+      };
+    } catch (writeError) {
+      return {
+        status: 'degraded',
+        message: 'Workspace directory is readable but not writable',
+        details: {
+          path: baseWorkspacePath,
+          readable: true,
+          writable: false,
+          writeError: writeError instanceof Error ? writeError.message : 'Unknown error',
+        },
+        timestamp,
+      };
+    }
+  } catch (error) {
+    return {
+      status: 'unhealthy',
+      message: 'Workspace directory is not accessible',
+      details: {
+        path: baseWorkspacePath,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      timestamp,
+    };
+  }
+}
+
+/**
+ * Check MCP configuration status
+ */
+export async function checkMcpConfig(): Promise<HealthCheckResult> {
+  const timestamp = new Date().toISOString();
+
+  try {
+    if (!isMcpEnabled()) {
+      return {
+        status: 'healthy',
+        message: 'MCP is disabled (no configuration file found)',
+        details: {
+          enabled: false,
+          configPath: process.env.MCP_CONFIG_PATH || path.join(__dirname, '..', 'mcp-config.json'),
+        },
+        timestamp,
+      };
+    }
+
+    const mcpConfig = getMcpConfig();
+    const serverCount = mcpConfig ? Object.keys(mcpConfig.mcpServers || {}).length : 0;
+
+    if (serverCount === 0) {
+      return {
+        status: 'degraded',
+        message: 'MCP is enabled but no servers configured',
+        details: {
+          enabled: true,
+          serverCount: 0,
+          configPath: process.env.MCP_CONFIG_PATH || path.join(__dirname, '..', 'mcp-config.json'),
+        },
+        timestamp,
+      };
+    }
+
+    return {
+      status: 'healthy',
+      message: 'MCP configuration is valid and servers are configured',
+      details: {
+        enabled: true,
+        serverCount,
+        servers: Object.keys(mcpConfig?.mcpServers || {}),
+        configPath: process.env.MCP_CONFIG_PATH || path.join(__dirname, '..', 'mcp-config.json'),
+      },
+      timestamp,
+    };
+  } catch (error) {
+    return {
+      status: 'unhealthy',
+      message: 'MCP configuration is invalid or corrupted',
+      details: {
+        enabled: true,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        configPath: process.env.MCP_CONFIG_PATH || path.join(__dirname, '..', 'mcp-config.json'),
+      },
+      timestamp,
+    };
+  }
+}
+
+/**
+ * Get process uptime in seconds
+ */
+export function getUptime(): number {
+  return process.uptime();
+}
+
+/**
+ * Get application version from package.json
+ */
+export async function getVersion(): Promise<string> {
+  try {
+    const packageJsonPath = path.join(__dirname, '..', 'package.json');
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+    return packageJson.version || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * Perform comprehensive health check
+ */
+export async function performHealthCheck(): Promise<HealthStatus> {
+  const timestamp = new Date().toISOString();
+
+  // Run all checks in parallel
+  const [claudeCli, workspace, mcpConfig, version] = await Promise.all([
+    checkClaudeCli(),
+    checkWorkspace(),
+    checkMcpConfig(),
+    getVersion(),
+  ]);
+
+  // Determine overall status
+  const checks = { claudeCli, workspace, mcpConfig };
+  const statuses = Object.values(checks).map(check => check.status);
+
+  let overallStatus: 'healthy' | 'unhealthy' | 'degraded';
+  if (statuses.includes('unhealthy')) {
+    overallStatus = 'unhealthy';
+  } else if (statuses.includes('degraded')) {
+    overallStatus = 'degraded';
+  } else {
+    overallStatus = 'healthy';
+  }
+
+  return {
+    status: overallStatus,
+    timestamp,
+    uptime: getUptime(),
+    version,
+    checks,
+  };
+}

--- a/tests/health-checker.test.ts
+++ b/tests/health-checker.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Health checker tests
+ */
+
+import { jest } from '@jest/globals';
+import { spawn } from 'child_process';
+import { promises as fs } from 'fs';
+import {
+  checkClaudeCli,
+  checkWorkspace,
+  checkMcpConfig,
+  performHealthCheck,
+  getUptime,
+  getVersion
+} from '../src/health-checker';
+import * as mcpManager from '../src/mcp-manager';
+
+// Mock dependencies
+jest.mock('child_process');
+jest.mock('fs', () => ({
+  promises: {
+    stat: jest.fn(),
+    mkdir: jest.fn(),
+    rmdir: jest.fn(),
+    readFile: jest.fn()
+  }
+}));
+jest.mock('../src/mcp-manager');
+
+const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+const mockFs = fs as jest.Mocked<typeof fs>;
+const mockMcpManager = mcpManager as jest.Mocked<typeof mcpManager>;
+
+describe('Health Checker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('checkClaudeCli', () => {
+    it('should return healthy when Claude CLI is available', async () => {
+      const mockProcess = {
+        stdout: {
+          on: jest.fn((event: string, callback: (data: Buffer) => void) => {
+            if (event === 'data') {
+              callback(Buffer.from('1.0.24 (Claude Code)\n'));
+            }
+          })
+        },
+        stderr: {
+          on: jest.fn()
+        },
+        on: jest.fn((event: string, callback: (code: number) => void) => {
+          if (event === 'close') {
+            callback(0); // Exit code 0 for success
+          }
+        }),
+        killed: false,
+        kill: jest.fn()
+      };
+
+      mockSpawn.mockReturnValue(mockProcess as any);
+
+      const result = await checkClaudeCli();
+
+      expect(result.status).toBe('healthy');
+      expect(result.message).toBe('Claude CLI is available and responsive');
+      expect(result.details).toMatchObject({
+        version: '1.0.24 (Claude Code)',
+        exitCode: 0
+      });
+      expect(result.timestamp).toBeDefined();
+    });
+
+    it('should return unhealthy when Claude CLI returns non-zero exit code', async () => {
+      const mockProcess = {
+        stdout: {
+          on: jest.fn()
+        },
+        stderr: {
+          on: jest.fn((event: string, callback: (data: Buffer) => void) => {
+            if (event === 'data') {
+              callback(Buffer.from('Command not found\n'));
+            }
+          })
+        },
+        on: jest.fn((event: string, callback: (code: number) => void) => {
+          if (event === 'close') {
+            callback(1); // Exit code 1 for error
+          }
+        }),
+        killed: false,
+        kill: jest.fn()
+      };
+
+      mockSpawn.mockReturnValue(mockProcess as any);
+
+      const result = await checkClaudeCli();
+
+      expect(result.status).toBe('unhealthy');
+      expect(result.message).toBe('Claude CLI returned non-zero exit code');
+      expect(result.details).toMatchObject({
+        exitCode: 1,
+        stderr: 'Command not found'
+      });
+    });
+
+    it('should return unhealthy when Claude CLI process errors', async () => {
+      const mockProcess = {
+        stdout: {
+          on: jest.fn()
+        },
+        stderr: {
+          on: jest.fn()
+        },
+        on: jest.fn((event: string, callback: (error: Error) => void) => {
+          if (event === 'error') {
+            callback(new Error('ENOENT: command not found'));
+          }
+        }),
+        killed: false,
+        kill: jest.fn()
+      };
+
+      mockSpawn.mockReturnValue(mockProcess as any);
+
+      const result = await checkClaudeCli();
+
+      expect(result.status).toBe('unhealthy');
+      expect(result.message).toBe('Claude CLI is not available or not working');
+      expect(result.details).toMatchObject({
+        error: 'ENOENT: command not found',
+        name: 'Error'
+      });
+    });
+
+    it('should handle timeout by killing process', async () => {
+      const mockProcess = {
+        stdout: {
+          on: jest.fn()
+        },
+        stderr: {
+          on: jest.fn()
+        },
+        on: jest.fn(),
+        killed: false,
+        kill: jest.fn()
+      };
+
+      mockSpawn.mockReturnValue(mockProcess as any);
+
+      // Start the check
+      const resultPromise = checkClaudeCli();
+
+      // Fast-forward time to trigger timeout
+      jest.advanceTimersByTime(5000);
+
+      const result = await resultPromise;
+
+      expect(result.status).toBe('unhealthy');
+      expect(result.message).toBe('Claude CLI check timed out');
+      expect(mockProcess.kill).toHaveBeenCalledWith('SIGTERM');
+    });
+  });
+
+  describe('checkWorkspace', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('should return healthy when workspace is accessible and writable', async () => {
+      const mockStats = { isDirectory: () => true };
+      mockFs.stat.mockResolvedValue(mockStats as any);
+      mockFs.mkdir.mockResolvedValue(undefined);
+      mockFs.rmdir.mockResolvedValue(undefined);
+
+      const result = await checkWorkspace();
+
+      expect(result.status).toBe('healthy');
+      expect(result.message).toBe('Workspace directory is accessible and writable');
+      expect(result.details).toMatchObject({
+        readable: true,
+        writable: true
+      });
+    });
+
+    it('should return unhealthy when workspace path is not a directory', async () => {
+      const mockStats = { isDirectory: () => false };
+      mockFs.stat.mockResolvedValue(mockStats as any);
+
+      const result = await checkWorkspace();
+
+      expect(result.status).toBe('unhealthy');
+      expect(result.message).toBe('Workspace base path is not a directory');
+      expect(result.details).toMatchObject({
+        type: 'file'
+      });
+    });
+
+    it('should return degraded when workspace is readable but not writable', async () => {
+      const mockStats = { isDirectory: () => true };
+      mockFs.stat.mockResolvedValue(mockStats as any);
+      mockFs.mkdir.mockRejectedValue(new Error('Permission denied'));
+
+      const result = await checkWorkspace();
+
+      expect(result.status).toBe('degraded');
+      expect(result.message).toBe('Workspace directory is readable but not writable');
+      expect(result.details).toMatchObject({
+        readable: true,
+        writable: false,
+        writeError: 'Permission denied'
+      });
+    });
+
+    it('should return unhealthy when workspace is not accessible', async () => {
+      mockFs.stat.mockRejectedValue(new Error('No such file or directory'));
+
+      const result = await checkWorkspace();
+
+      expect(result.status).toBe('unhealthy');
+      expect(result.message).toBe('Workspace directory is not accessible');
+      expect(result.details).toMatchObject({
+        error: 'No such file or directory'
+      });
+    });
+
+    it('should use WORKSPACE_BASE_PATH environment variable', async () => {
+      process.env.WORKSPACE_BASE_PATH = '/custom/workspace';
+      const mockStats = { isDirectory: () => true };
+      mockFs.stat.mockResolvedValue(mockStats as any);
+      mockFs.mkdir.mockResolvedValue(undefined);
+      mockFs.rmdir.mockResolvedValue(undefined);
+
+      const result = await checkWorkspace();
+
+      expect(mockFs.stat).toHaveBeenCalledWith('/custom/workspace');
+      expect(result.status).toBe('healthy');
+      expect(result.details?.path).toBe('/custom/workspace');
+    });
+  });
+
+  describe('checkMcpConfig', () => {
+    it('should return healthy when MCP is disabled', async () => {
+      mockMcpManager.isMcpEnabled.mockReturnValue(false);
+
+      const result = await checkMcpConfig();
+
+      expect(result.status).toBe('healthy');
+      expect(result.message).toBe('MCP is disabled (no configuration file found)');
+      expect(result.details).toMatchObject({
+        enabled: false
+      });
+    });
+
+    it('should return degraded when MCP is enabled but no servers configured', async () => {
+      mockMcpManager.isMcpEnabled.mockReturnValue(true);
+      mockMcpManager.getMcpConfig.mockReturnValue({
+        mcpServers: {}
+      });
+
+      const result = await checkMcpConfig();
+
+      expect(result.status).toBe('degraded');
+      expect(result.message).toBe('MCP is enabled but no servers configured');
+      expect(result.details).toMatchObject({
+        enabled: true,
+        serverCount: 0
+      });
+    });
+
+    it('should return healthy when MCP is enabled with servers configured', async () => {
+      mockMcpManager.isMcpEnabled.mockReturnValue(true);
+      mockMcpManager.getMcpConfig.mockReturnValue({
+        mcpServers: {
+          'github': { command: 'npx', args: ['-y', '@modelcontextprotocol/server-github'] },
+          'deepwiki': { command: 'uv', args: ['--directory', 'servers/src/deepwiki', 'run', 'deepwiki'] }
+        }
+      });
+
+      const result = await checkMcpConfig();
+
+      expect(result.status).toBe('healthy');
+      expect(result.message).toBe('MCP configuration is valid and servers are configured');
+      expect(result.details).toMatchObject({
+        enabled: true,
+        serverCount: 2,
+        servers: ['github', 'deepwiki']
+      });
+    });
+
+    it('should return unhealthy when MCP configuration is invalid', async () => {
+      mockMcpManager.isMcpEnabled.mockReturnValue(true);
+      mockMcpManager.getMcpConfig.mockImplementation(() => {
+        throw new Error('Invalid JSON');
+      });
+
+      const result = await checkMcpConfig();
+
+      expect(result.status).toBe('unhealthy');
+      expect(result.message).toBe('MCP configuration is invalid or corrupted');
+      expect(result.details).toMatchObject({
+        enabled: true,
+        error: 'Invalid JSON'
+      });
+    });
+
+    it('should use MCP_CONFIG_PATH environment variable', async () => {
+      const originalEnv = process.env;
+      process.env = { ...originalEnv, MCP_CONFIG_PATH: '/custom/mcp-config.json' };
+
+      mockMcpManager.isMcpEnabled.mockReturnValue(false);
+
+      const result = await checkMcpConfig();
+
+      expect(result.details?.configPath).toBe('/custom/mcp-config.json');
+
+      process.env = originalEnv;
+    });
+  });
+
+  describe('getUptime', () => {
+    it('should return process uptime', () => {
+      const originalUptime = process.uptime;
+      process.uptime = jest.fn(() => 123.456);
+
+      const uptime = getUptime();
+
+      expect(uptime).toBe(123.456);
+
+      process.uptime = originalUptime;
+    });
+  });
+
+  describe('getVersion', () => {
+    it('should return version from package.json', async () => {
+      mockFs.readFile.mockResolvedValue('{"version": "1.0.0"}');
+
+      const version = await getVersion();
+
+      expect(version).toBe('1.0.0');
+      expect(mockFs.readFile).toHaveBeenCalledWith(
+        expect.stringContaining('package.json'),
+        'utf-8'
+      );
+    });
+
+    it('should return "unknown" when package.json cannot be read', async () => {
+      mockFs.readFile.mockRejectedValue(new Error('File not found'));
+
+      const version = await getVersion();
+
+      expect(version).toBe('unknown');
+    });
+
+    it('should return "unknown" when package.json has no version', async () => {
+      mockFs.readFile.mockResolvedValue('{"name": "test"}');
+
+      const version = await getVersion();
+
+      expect(version).toBe('unknown');
+    });
+  });
+
+  describe('performHealthCheck', () => {
+    it('should return overall healthy status when all checks pass', async () => {
+      // Mock spawn to return healthy CLI check
+      const mockProcess = {
+        stdout: { on: jest.fn((event: string, callback: (data: Buffer) => void) => {
+          if (event === 'data') callback(Buffer.from('1.0.24 (Claude Code)\n'));
+        }) },
+        stderr: { on: jest.fn() },
+        on: jest.fn((event: string, callback: (code: number) => void) => {
+          if (event === 'close') callback(0);
+        }),
+        killed: false,
+        kill: jest.fn()
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+
+      // Mock workspace as accessible
+      const mockStats = { isDirectory: () => true };
+      mockFs.stat.mockResolvedValue(mockStats as any);
+      mockFs.mkdir.mockResolvedValue(undefined);
+      mockFs.rmdir.mockResolvedValue(undefined);
+
+      // Mock MCP as disabled
+      mockMcpManager.isMcpEnabled.mockReturnValue(false);
+
+      // Mock package.json reading
+      mockFs.readFile.mockResolvedValue('{"version": "1.0.0"}');
+
+      const result = await performHealthCheck();
+
+      expect(result.status).toBe('healthy');
+      expect(result.version).toBe('1.0.0');
+      expect(result.checks).toHaveProperty('claudeCli');
+      expect(result.checks).toHaveProperty('workspace');
+      expect(result.checks).toHaveProperty('mcpConfig');
+    });
+
+    it('should return degraded status when workspace is degraded', async () => {
+      // Mock spawn to return healthy CLI check
+      const mockProcess = {
+        stdout: { on: jest.fn((event: string, callback: (data: Buffer) => void) => {
+          if (event === 'data') callback(Buffer.from('1.0.24 (Claude Code)\n'));
+        }) },
+        stderr: { on: jest.fn() },
+        on: jest.fn((event: string, callback: (code: number) => void) => {
+          if (event === 'close') callback(0);
+        }),
+        killed: false,
+        kill: jest.fn()
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+
+      // Mock workspace as readable but not writable
+      const mockStats = { isDirectory: () => true };
+      mockFs.stat.mockResolvedValue(mockStats as any);
+      mockFs.mkdir.mockRejectedValue(new Error('Permission denied'));
+
+      // Mock MCP as disabled
+      mockMcpManager.isMcpEnabled.mockReturnValue(false);
+
+      // Mock package.json reading
+      mockFs.readFile.mockResolvedValue('{"version": "1.0.0"}');
+
+      const result = await performHealthCheck();
+
+      expect(result.status).toBe('degraded');
+    });
+
+    it('should return unhealthy status when CLI is unhealthy', async () => {
+      // Mock spawn to return error
+      const mockProcess = {
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        on: jest.fn((event: string, callback: (error: Error) => void) => {
+          if (event === 'error') callback(new Error('Command not found'));
+        }),
+        killed: false,
+        kill: jest.fn()
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+
+      // Mock workspace as accessible
+      const mockStats = { isDirectory: () => true };
+      mockFs.stat.mockResolvedValue(mockStats as any);
+      mockFs.mkdir.mockResolvedValue(undefined);
+      mockFs.rmdir.mockResolvedValue(undefined);
+
+      // Mock MCP as disabled
+      mockMcpManager.isMcpEnabled.mockReturnValue(false);
+
+      // Mock package.json reading
+      mockFs.readFile.mockResolvedValue('{"version": "1.0.0"}');
+
+      const result = await performHealthCheck();
+
+      expect(result.status).toBe('unhealthy');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive health monitoring system with GET /health endpoint
- Check Claude CLI availability and version
- Verify workspace directory accessibility and permissions  
- Monitor MCP configuration status
- Return appropriate HTTP status codes (200/503/500) based on health
- Include uptime, version, and detailed check results

## Changes Made
- **src/health-checker.ts**: New health monitoring system with individual check functions
- **src/server.ts**: Added GET /health endpoint with error handling
- **README.md**: Updated with health endpoint documentation, status codes, and examples
- **CLAUDE.md**: Updated testing section and architecture documentation

## Health Check Features
### Health Status Levels
- `healthy` - All systems operational  
- `degraded` - Issues detected but still functional
- `unhealthy` - Critical issues, service may not work properly

### Individual Checks
- **Claude CLI**: Availability and version check with 5-second timeout
- **Workspace**: Directory accessibility and write permission verification
- **MCP Config**: Configuration validity and server count monitoring

### Response Format
```json
{
  "status": "healthy",
  "timestamp": "2025-06-14T16:25:58.963Z", 
  "uptime": 129.465,
  "version": "1.0.0",
  "checks": {
    "claudeCli": { "status": "healthy", "message": "...", "details": {...} },
    "workspace": { "status": "healthy", "message": "...", "details": {...} },
    "mcpConfig": { "status": "healthy", "message": "...", "details": {...} }
  }
}
```

## Test Plan
- [x] TypeScript compilation succeeds
- [x] ESLint passes without errors
- [x] Health endpoint returns proper JSON response
- [x] All individual checks function correctly
- [x] HTTP status codes work as expected (200 for healthy/degraded, 503 for unhealthy)
- [x] Documentation is comprehensive and accurate

Resolves #21

🤖 Generated with [Claude Code](https://claude.ai/code)