### PR TITLE
improve: make thinking blocks dynamic instead of always starting

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -489,8 +489,6 @@ async function startServer(): Promise<void> {
                   const toolsStr = mcpAllowedTools.map(tool => `"${tool}"`).join(',');
                   sessionInfo += `mcp-allowed-tools=[${toolsStr}]\n`;
                 }
-                sessionInfo += '<thinking>\n';
-                inThinking = true;
 
                 // Send initial chunk with role
                 const roleChunk = {
@@ -574,14 +572,14 @@ async function startServer(): Promise<void> {
                 }
               }
 
-              // Close thinking if still open at end of final response
-              if (isFinalResponse && inThinking) {
-                sendChunk('\n</thinking>\n');
-                inThinking = false;
-              }
-
               // Send empty delta with finish_reason for final response (if text didn't already send it)
               if (isFinalResponse && content.every(item => item.type !== 'text')) {
+                // Close thinking if still open at end of final response
+                if (inThinking) {
+                  sendChunk('\n</thinking>\n');
+                  inThinking = false;
+                }
+
                 const finalChunk = {
                   id: messageId,
                   object: 'chat.completion.chunk',


### PR DESCRIPTION
## Summary
- Remove fixed thinking block initialization to prevent unnecessary thinking tags when no thinking content is present
- Move thinking block closing logic to only occur when there's actually thinking content to close
- Thinking blocks now only appear when actual thinking content is received from Claude

## Test plan
- [ ] Test streaming responses without thinking content (should not have empty `<thinking></thinking>` tags)
- [ ] Test streaming responses with thinking content (should properly open and close thinking blocks)
- [ ] Verify final response handling when thinking blocks are open

🤖 Generated with [Claude Code](https://claude.ai/code)